### PR TITLE
Configuration Fixes

### DIFF
--- a/lib/Dancer2/Template/TextTemplate.pm
+++ b/lib/Dancer2/Template/TextTemplate.pm
@@ -149,8 +149,8 @@ has '+engine' =>
 sub _build_engine {
     my $self = shift;
     my $engine = Dancer2::Template::TextTemplate::FakeEngine->new;
-    for (qw/ caching expires delimiters cache_stringrefs prepend /) {
-        $engine->$_($self->config->{$_}) if $self->config->{$_};
+    for (qw/ caching expires delimiters cache_stringrefs prepend safe /) {
+        $engine->$_($self->config->{$_}) if exists $self->config->{$_};
     }
     return $engine;
 }


### PR DESCRIPTION
1. Add safe to the list of values passed through to the engine construct…
2. Allow users to set false values for boolean options by changing the check to exists instead of a base boolean check.